### PR TITLE
forceReload surveys only on page refresh

### DIFF
--- a/site.ts
+++ b/site.ts
@@ -221,7 +221,7 @@ export function inject({ config, posthog }) {
         })
     }
 
-    const callSurveys = (posthog) => {
+    const callSurveys = (posthog, forceReload = false) => {
         posthog?.getActiveMatchingSurveys((surveys) => {
             surveys.forEach((survey) => {
                 if (document.querySelectorAll("div[class^='PostHogSurvey']").length === 0) {
@@ -240,17 +240,17 @@ export function inject({ config, posthog }) {
                     }
                 }
             })
-        }, true)
+        }, forceReload)
     }
 
-    callSurveys(posthog)
+    callSurveys(posthog, true)
 
     let currentUrl = location.href
     if (location.href) {
         setInterval(() => {
             if (location.href !== currentUrl) {
                 currentUrl = location.href
-                callSurveys(posthog)
+                callSurveys(posthog, false)
             }
         }, 1500)
     }


### PR DESCRIPTION
Now that we're polling for surveys, it's unnecessary to force reload on each poll, we can do just as well by reloading only on page refresh.

P.s: Haven't tested this yet 🙈 