### PR TITLE
Whitelabel option

### DIFF
--- a/site.ts
+++ b/site.ts
@@ -432,6 +432,9 @@ export function inject({ config, posthog }) {
                         surveyPopup = createMultipleChoicePopup(survey)
                     }
                     addCancelListeners(surveyPopup, survey.id, survey.name)
+                    if (survey.appearance?.whiteLabel) {
+                        surveyPopup.getElementsByClassName('footer-branding')[0].style.display = 'none'
+                    }
                     shadow.appendChild(surveyPopup)
 
                     window.dispatchEvent(new Event('PHSurveyShown'))


### PR DESCRIPTION
Allow surveys to not have posthog's branding on them

<img width="403" alt="Screen Shot 2023-08-28 at 1 08 41 PM" src="https://github.com/PostHog/feature-surveys/assets/25164963/b9ae8d9f-fa08-4936-b742-c9977a81f365">
