### PR TITLE
feat: Don't use site app if posthog-js natively supports surveys

### DIFF
--- a/site.ts
+++ b/site.ts
@@ -230,6 +230,11 @@ export function inject({ config, posthog }) {
         }
     }
 
+    if (window?.generateSurveys) {
+        // If posthog-js natively supports surveys, don't do anything with the app
+        return
+    }
+
     callSurveys(posthog, true)
 
     let currentUrl = location.href
@@ -258,6 +263,12 @@ export const createShadow = (styleSheet, surveyId) => {
 }
 
 export const callSurveys = (posthog, forceReload = false) => {
+
+    if (window?.generateSurveys) {
+        // If posthog-js natively supports surveys, don't do anything with the app
+        return
+    }
+    
     posthog?.getActiveMatchingSurveys((surveys) => {
         const nonAPISurveys = surveys.filter(survey => survey.type !== 'api')
         nonAPISurveys.forEach((survey) => {

--- a/site.ts
+++ b/site.ts
@@ -230,7 +230,7 @@ export function inject({ config, posthog }) {
         }
     }
 
-    if (window?.generateSurveys) {
+    if (window?.extendPostHogWithSurveys) {
         // If posthog-js natively supports surveys, don't do anything with the app
         return
     }
@@ -264,7 +264,7 @@ export const createShadow = (styleSheet, surveyId) => {
 
 export const callSurveys = (posthog, forceReload = false) => {
 
-    if (window?.generateSurveys) {
+    if (window?.extendPostHogWithSurveys) {
         // If posthog-js natively supports surveys, don't do anything with the app
         return
     }


### PR DESCRIPTION
Part 2 of X of deprecating site apps.

Follows from https://github.com/PostHog/posthog-js/pull/801

